### PR TITLE
Fix: trailers should not have whitespace padding for grpc-status

### DIFF
--- a/client/grpc-web-react-example/go/exampleserver/exampleserver.go
+++ b/client/grpc-web-react-example/go/exampleserver/exampleserver.go
@@ -14,8 +14,8 @@ import (
 
 	"strings"
 
-	library "github.com/improbable-eng/grpc-web/client/grpc-web-react-example/go/_proto/examplecom/library"
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
+	library "github.com/rigetti/grpc-web/client/grpc-web-react-example/go/_proto/examplecom/library"
+	"github.com/rigetti/grpc-web/go/grpcweb"
 	"golang.org/x/net/context"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/improbable-eng/grpc-web
+module github.com/rigetti/grpc-web
 
 go 1.16
 

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -133,8 +133,13 @@ func extractTrailingHeaders(src http.Header, flushed http.Header) http.Header {
 // See https://github.com/golang/go/blob/master/src/net/http/header.go#L208
 func writeGrpcStatusTrailer(src http.Header, buf *bytes.Buffer) {
 	const headerName = "grpc-status"
-	if status := strings.TrimSpace(src.Get(headerName)); status != "" {
-		src.Del(headerName)
+	// `grpc-status` will have been added all lowercase, not in
+	// the `http.CanonicalHeaderKey` form, so we must access the
+	// header map directly instead of `src.Get`.
+	if statuses, ok := src[headerName]; ok && len(statuses) > 0 {
+		status := statuses[0]
+		delete(src, headerName)
+
 		buf.WriteString(headerName + ":" + status + "\r\n")
 	}
 }

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -115,6 +115,7 @@ func extractTrailingHeaders(src http.Header, flushed http.Header) http.Header {
 		// "HTTP wire protocols" section in
 		// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2
 		keyCase(strings.ToLower),
+		trimGrpcStatus(),
 	)
 	return th
 }

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -76,6 +76,7 @@ func (w *grpcWebResponse) prepareHeaders() {
 		replaceInKeys(http2.TrailerPrefix, ""),
 		replaceInVals("content-type", grpcContentType, w.contentType),
 		keyCase(http.CanonicalHeaderKey),
+		trimGrpcStatus(),
 	)
 	responseHeaderKeys := headerKeys(wh)
 	responseHeaderKeys = append(responseHeaderKeys, "grpc-status", "grpc-message")

--- a/go/grpcweb/grpc_web_response.go
+++ b/go/grpcweb/grpc_web_response.go
@@ -78,6 +78,7 @@ func (w *grpcWebResponse) prepareHeaders() {
 		keyCase(http.CanonicalHeaderKey),
 		trimGrpcStatus(),
 	)
+	wh.Set("grpc-status", strings.TrimSpace(wh.Get("grpc-status")))
 	responseHeaderKeys := headerKeys(wh)
 	responseHeaderKeys = append(responseHeaderKeys, "grpc-status", "grpc-message")
 	wh.Set(
@@ -118,6 +119,7 @@ func extractTrailingHeaders(src http.Header, flushed http.Header) http.Header {
 		keyCase(strings.ToLower),
 		trimGrpcStatus(),
 	)
+	th.Set("grpc-status", strings.TrimSpace(th.Get("grpc-status")))
 	return th
 }
 

--- a/go/grpcweb/header.go
+++ b/go/grpcweb/header.go
@@ -77,25 +77,6 @@ func replaceInKeys(old, new string) copyOption {
 	}
 }
 
-// trimGrpcStatus removes the whitespace from the value in the grpc-status header.
-func trimGrpcStatus() copyOption {
-	return func(opts *copyOptions) {
-		opts.replacers = append(
-			opts.replacers,
-			func(k string, vv []string) (string, []string, bool) {
-				if strings.ToLower(k) == "grpc-status" {
-					vv2 := make([]string, 0, len(vv))
-					for _, v := range vv {
-						vv2 = append(vv2, strings.TrimSpace(v))
-					}
-					return k, vv2, true
-				}
-				return "", nil, false
-			},
-		)
-	}
-}
-
 // keyCase returns an option to unconditionally modify the case of the
 // destination header keys with function fn. Typically fn can be
 // strings.ToLower, strings.ToUpper, http.CanonicalHeaderKey

--- a/go/grpcweb/header.go
+++ b/go/grpcweb/header.go
@@ -85,8 +85,8 @@ func trimGrpcStatus() copyOption {
 			func(k string, vv []string) (string, []string, bool) {
 				if strings.ToLower(k) == "grpc-status" {
 					vv2 := make([]string, 0, len(vv))
-					for i, v := range vv {
-						vv2[i] = strings.TrimSpace(v)
+					for _, v := range vv {
+						vv2 = append(vv2, strings.TrimSpace(v))
 					}
 					return k, vv2, true
 				}

--- a/go/grpcweb/header.go
+++ b/go/grpcweb/header.go
@@ -77,6 +77,25 @@ func replaceInKeys(old, new string) copyOption {
 	}
 }
 
+// trimGrpcStatus removes the whitespace from the value in the grpc-status header.
+func trimGrpcStatus() copyOption {
+	return func(opts *copyOptions) {
+		opts.replacers = append(
+			opts.replacers,
+			func(k string, vv []string) (string, []string, bool) {
+				if strings.ToLower(k) == "grpc-status" {
+					vv2 := make([]string, 0, len(vv))
+					for i, v := range vv {
+						vv2[i] = strings.TrimSpace(v)
+					}
+					return k, vv2, true
+				}
+				return "", nil, false
+			},
+		)
+	}
+}
+
 // keyCase returns an option to unconditionally modify the case of the
 // destination header keys with function fn. Typically fn can be
 // strings.ToLower, strings.ToUpper, http.CanonicalHeaderKey

--- a/go/grpcweb/health_test.go
+++ b/go/grpcweb/health_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
-	testproto "github.com/improbable-eng/grpc-web/integration_test/go/_proto/improbable/grpcweb/test"
+	"github.com/rigetti/grpc-web/go/grpcweb"
+	testproto "github.com/rigetti/grpc-web/integration_test/go/_proto/improbable/grpcweb/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"

--- a/go/grpcweb/helpers_test.go
+++ b/go/grpcweb/helpers_test.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"testing"
 
-	testproto "github.com/improbable-eng/grpc-web/integration_test/go/_proto/improbable/grpcweb/test"
+	testproto "github.com/rigetti/grpc-web/integration_test/go/_proto/improbable/grpcweb/test"
 
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
+	"github.com/rigetti/grpc-web/go/grpcweb"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )

--- a/go/grpcweb/wrapper_test.go
+++ b/go/grpcweb/wrapper_test.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
-	testproto "github.com/improbable-eng/grpc-web/integration_test/go/_proto/improbable/grpcweb/test"
 	"github.com/mwitkow/go-conntrack/connhelpers"
+	"github.com/rigetti/grpc-web/go/grpcweb"
+	testproto "github.com/rigetti/grpc-web/integration_test/go/_proto/improbable/grpcweb/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/go/grpcwebproxy/main.go
+++ b/go/grpcwebproxy/main.go
@@ -17,10 +17,10 @@ import (
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/mwitkow/go-conntrack"
 	"github.com/mwitkow/grpc-proxy/proxy"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rigetti/grpc-web/go/grpcweb"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
@@ -216,7 +216,7 @@ func buildGrpcProxyServer(backendConn *grpc.ClientConn, logger *logrus.Entry) *g
 		delete(mdCopy, "user-agent")
 		// If this header is present in the request from the web client,
 		// the actual connection to the backend will not be established.
-		// https://github.com/improbable-eng/grpc-web/issues/568
+		// https://github.com/rigetti/grpc-web/issues/568
 		delete(mdCopy, "connection")
 		outCtx = metadata.NewOutgoingContext(outCtx, mdCopy)
 		return outCtx, backendConn, nil

--- a/integration_test/go/testserver/testserver.go
+++ b/integration_test/go/testserver/testserver.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
-	"github.com/improbable-eng/grpc-web/go/grpcweb"
-	testproto "github.com/improbable-eng/grpc-web/integration_test/go/_proto/improbable/grpcweb/test"
+	"github.com/rigetti/grpc-web/go/grpcweb"
+	testproto "github.com/rigetti/grpc-web/integration_test/go/_proto/improbable/grpcweb/test"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"


### PR DESCRIPTION
[tonic can’t handle whitespace padding](https://github.com/hyperium/tonic/blob/522a8d74f8a948d48cb6b5ae0f591d02388e930d/tonic/src/status.rs#L787) but [net/http](https://github.com/golang/go/blob/master/src/net/http/header.go#L208) will always add it. This formats `grpc-status` into the trailer without padding. 